### PR TITLE
basic installation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "pretest": "cp config.json test/test-config.json",
     "test": "xo --space --env=mocha && mocha",
-    "posttest": "rm test/test-config.json"
+    "posttest": "rm test/test-config.json",
+    "install": "cp config.json $HOME/.search-cli.json"
   },
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
- it's simple and only works for osx, linux.
- still need to add windows support for launcher and install step (don't have
  a windows machine or an window key to install on a vm)
